### PR TITLE
Implement Logical and Shift Instructions

### DIFF
--- a/src/core/cpu/mod.rs
+++ b/src/core/cpu/mod.rs
@@ -428,22 +428,22 @@ impl CPU {
         let (rs, rt, rd, shamt, funct) = decode_r_type(instruction);
 
         match funct {
-            0x00 => self.op_sll(rt, rd, shamt),  // SLL
-            0x02 => self.op_srl(rt, rd, shamt),  // SRL
-            0x03 => self.op_sra(rt, rd, shamt),  // SRA
-            0x04 => self.op_sllv(rs, rt, rd),    // SLLV
-            0x06 => self.op_srlv(rs, rt, rd),    // SRLV
-            0x07 => self.op_srav(rs, rt, rd),    // SRAV
-            0x20 => self.op_add(rs, rt, rd),     // ADD
-            0x21 => self.op_addu(rs, rt, rd),    // ADDU
-            0x22 => self.op_sub(rs, rt, rd),     // SUB
-            0x23 => self.op_subu(rs, rt, rd),    // SUBU
-            0x24 => self.op_and(rs, rt, rd),     // AND
-            0x25 => self.op_or(rs, rt, rd),      // OR
-            0x26 => self.op_xor(rs, rt, rd),     // XOR
-            0x27 => self.op_nor(rs, rt, rd),     // NOR
-            0x2A => self.op_slt(rs, rt, rd),     // SLT
-            0x2B => self.op_sltu(rs, rt, rd),    // SLTU
+            0x00 => self.op_sll(rt, rd, shamt), // SLL
+            0x02 => self.op_srl(rt, rd, shamt), // SRL
+            0x03 => self.op_sra(rt, rd, shamt), // SRA
+            0x04 => self.op_sllv(rs, rt, rd),   // SLLV
+            0x06 => self.op_srlv(rs, rt, rd),   // SRLV
+            0x07 => self.op_srav(rs, rt, rd),   // SRAV
+            0x20 => self.op_add(rs, rt, rd),    // ADD
+            0x21 => self.op_addu(rs, rt, rd),   // ADDU
+            0x22 => self.op_sub(rs, rt, rd),    // SUB
+            0x23 => self.op_subu(rs, rt, rd),   // SUBU
+            0x24 => self.op_and(rs, rt, rd),    // AND
+            0x25 => self.op_or(rs, rt, rd),     // OR
+            0x26 => self.op_xor(rs, rt, rd),    // XOR
+            0x27 => self.op_nor(rs, rt, rd),    // NOR
+            0x2A => self.op_slt(rs, rt, rd),    // SLT
+            0x2B => self.op_sltu(rs, rt, rd),   // SLTU
             _ => {
                 log::warn!(
                     "Unimplemented SPECIAL function: 0x{:02X} at PC=0x{:08X}",


### PR DESCRIPTION
## Summary
Implements MIPS logical operations (AND, OR, XOR, NOR) and shift instructions (SLL, SRL, SRA, etc.) for the R3000A CPU emulator.

Closes #7

## Changes

### Logical Instructions
**R-type (register operations):**
- `AND rd, rs, rt` - Bitwise AND
- `OR rd, rs, rt` - Bitwise OR
- `XOR rd, rs, rt` - Bitwise XOR
- `NOR rd, rs, rt` - Bitwise NOR (NOT OR)

**I-type (immediate operations with zero-extension):**
- `ANDI rt, rs, imm` - AND immediate (zero-extended)
- `ORI rt, rs, imm` - OR immediate (zero-extended)
- `XORI rt, rs, imm` - XOR immediate (zero-extended)

### Shift Instructions
**Fixed shift amount:**
- `SRL rd, rt, shamt` - Shift right logical (zero-fill)
- `SRA rd, rt, shamt` - Shift right arithmetic (sign-extend)

**Variable shift amount:**
- `SLLV rd, rt, rs` - Shift left logical variable
- `SRLV rd, rt, rs` - Shift right logical variable
- `SRAV rd, rt, rs` - Shift right arithmetic variable

### Implementation Details
- **Zero-extension**: ANDI/ORI/XORI use zero-extension (not sign-extension)
- **Sign-extension**: SRA/SRAV preserve the sign bit correctly
- **5-bit masking**: Variable shifts mask shift amount to lower 5 bits (0-31 range)
- **Dispatcher integration**: All instructions added to execute_special() and execute_instruction()

## Testing
- **32 new unit tests** covering:
  - Zero-extension behavior for immediate logical operations
  - Sign-extension for arithmetic right shifts
  - 5-bit masking for variable shift amounts
  - Edge cases (all zeros, all ones, overflow, etc.)
- **All 84 tests pass** with no warnings
- **Clippy clean** - no linter warnings

## Files Changed
- `src/core/cpu/mod.rs` (+555, -7)
  - Added 13 instruction implementations (lines 847-1099)
  - Updated instruction dispatcher (lines 390-453)
  - Added comprehensive unit tests (lines 2104-2367)

## Verification
```bash
cargo test --lib cpu        # All 84 tests pass
cargo clippy --all-targets  # No warnings
cargo build                 # Compiles successfully
```

## Technical Notes
- Follows MIPS R3000A specification exactly
- Consistent with existing coding standards and documentation style
- All instructions are 1-cycle operations (as per current design)
- Properly handles r0 hardwired-to-zero behavior

## Next Steps
After merge, the following instructions remain for future PRs:
- Load/Store instructions (LW, SW, LB, SB, etc.)
- Branch instructions (BEQ, BNE, BGTZ, etc.)
- Multiplication/Division (MULT, DIV, MFHI, MFLO)
- Coprocessor operations (MFC0, MTC0, RFE)

## References
- Issue #7: Implement Logical and Shift Instructions
- [MIPS Instruction Set Reference](specs/04-reference/mips-instruction-set.md)
- [CPU Design Documentation](specs/01-design/cpu-design.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded CPU instruction set with logical operations (AND, OR, XOR, NOR) and shift operations (SLL, SRL, SRA).
  * Added immediate instruction variants for logical operations (ANDI, ORI, XORI).
  * Support for register-variant shift operations.

* **Tests**
  * Comprehensive test coverage for new logical and shift instructions with varied edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->