### PR TITLE
Implement Solid Color Polygon Rendering

### DIFF
--- a/src/core/gpu/mod.rs
+++ b/src/core/gpu/mod.rs
@@ -1517,16 +1517,16 @@ impl GPU {
     ) {
         // Apply drawing offset
         let v0 = Vertex {
-            x: vertices[0].x + self.draw_offset.0,
-            y: vertices[0].y + self.draw_offset.1,
+            x: vertices[0].x.wrapping_add(self.draw_offset.0),
+            y: vertices[0].y.wrapping_add(self.draw_offset.1),
         };
         let v1 = Vertex {
-            x: vertices[1].x + self.draw_offset.0,
-            y: vertices[1].y + self.draw_offset.1,
+            x: vertices[1].x.wrapping_add(self.draw_offset.0),
+            y: vertices[1].y.wrapping_add(self.draw_offset.1),
         };
         let v2 = Vertex {
-            x: vertices[2].x + self.draw_offset.0,
-            y: vertices[2].y + self.draw_offset.1,
+            x: vertices[2].x.wrapping_add(self.draw_offset.0),
+            y: vertices[2].y.wrapping_add(self.draw_offset.1),
         };
 
         log::trace!(
@@ -1553,7 +1553,7 @@ impl GPU {
 
     /// Render a monochrome (flat-shaded) quadrilateral
     ///
-    /// Quads are rendered as two triangles: (v0, v1, v2) and (v1, v2, v3).
+    /// Quads are rendered as two triangles: (v0, v1, v2) and (v0, v2, v3).
     /// Applies the drawing offset and delegates to triangle rendering.
     ///
     /// # Arguments
@@ -1569,7 +1569,7 @@ impl GPU {
     ) {
         // Quads are rendered as two triangles
         let tri1 = [vertices[0], vertices[1], vertices[2]];
-        let tri2 = [vertices[1], vertices[2], vertices[3]];
+        let tri2 = [vertices[0], vertices[2], vertices[3]];
 
         self.render_monochrome_triangle(&tri1, color, semi_transparent);
         self.render_monochrome_triangle(&tri2, color, semi_transparent);


### PR DESCRIPTION
## Summary

Implements GP0 commands for rendering solid color polygons (triangles and quadrilaterals),
which are the foundation of PSX 3D graphics rendering.

Closes #32

## Changes

### Core Implementation

**Polygon Primitives** (`src/core/gpu/mod.rs`):
- `Color` struct: 24-bit RGB with conversion to 15-bit VRAM format
- `Vertex` struct: 2D signed coordinates from command words
- `GPUCommand` enum: MonochromeTriangle, MonochromeQuad variants

**Command Parsing**:
- GP0(0x20): Monochrome triangle (opaque)
- GP0(0x22): Monochrome triangle (semi-transparent)
- GP0(0x28): Monochrome quad (opaque)
- GP0(0x2A): Monochrome quad (semi-transparent)

**Rendering Infrastructure**:
- `render_monochrome_triangle()`: Applies drawing offset, logs operation (rasterization stub)
- `render_monochrome_quad()`: Splits quad into two triangles
- Drawing offset properly applied to all vertices
- Semi-transparency flag tracked for future blending

### Testing

Added 11 comprehensive tests:
- Color/vertex extraction from command words
- RGB 24-bit to 15-bit conversion
- All 4 monochrome polygon command types
- Drawing offset application
- Command FIFO buffering behavior
- Quad splitting into triangles
- Negative coordinate handling

### Bug Fixes

Fixed compilation errors in existing tests that referenced removed `current_command` field.

## Test Results

```
running 63 tests
test result: ok. 63 passed; 0 failed; 0 ignored
```

No clippy warnings. Code formatted with `cargo x fmt`.

## Architecture Notes

- Commands buffered in FIFO until complete
- Actual rasterization deferred to issue #33
- Design follows PSX-SPX polygon command format exactly
- Quad rendering matches hardware behavior (two triangle split)

## Next Steps

Issue #33 will implement the actual rasterizer to draw pixels for these polygon commands.

## Checklist

- [x] All acceptance criteria met
- [x] Unit tests added and passing
- [x] No clippy warnings
- [x] Code formatted
- [x] Documentation complete
- [x] Follows CLAUDE.md conventions
# PR: Implement Solid Color Polygon Rendering

## Summary

Implements GP0 commands for rendering solid color polygons (triangles and quadrilaterals),
which are the foundation of PSX 3D graphics rendering.

Closes #32

## Changes

### Core Implementation

**Polygon Primitives** (`src/core/gpu/mod.rs`):
- `Color` struct: 24-bit RGB with conversion to 15-bit VRAM format
- `Vertex` struct: 2D signed coordinates from command words
- `GPUCommand` enum: MonochromeTriangle, MonochromeQuad variants

**Command Parsing**:
- GP0(0x20): Monochrome triangle (opaque)
- GP0(0x22): Monochrome triangle (semi-transparent)
- GP0(0x28): Monochrome quad (opaque)
- GP0(0x2A): Monochrome quad (semi-transparent)

**Rendering Infrastructure**:
- `render_monochrome_triangle()`: Applies drawing offset, logs operation (rasterization stub)
- `render_monochrome_quad()`: Splits quad into two triangles
- Drawing offset properly applied to all vertices
- Semi-transparency flag tracked for future blending

### Testing

Added 11 comprehensive tests:
- Color/vertex extraction from command words
- RGB 24-bit to 15-bit conversion
- All 4 monochrome polygon command types
- Drawing offset application
- Command FIFO buffering behavior
- Quad splitting into triangles
- Negative coordinate handling

### Bug Fixes

Fixed compilation errors in existing tests that referenced removed `current_command` field.

## Test Results

```
running 63 tests
test result: ok. 63 passed; 0 failed; 0 ignored
```

No clippy warnings. Code formatted with `cargo x fmt`.

## Architecture Notes

- Commands buffered in FIFO until complete
- Actual rasterization deferred to issue #33
- Design follows PSX-SPX polygon command format exactly
- Quad rendering matches hardware behavior (two triangle split)

## Next Steps

Issue #33 will implement the actual rasterizer to draw pixels for these polygon commands.

## Checklist

- [x] All acceptance criteria met
- [x] Unit tests added and passing
- [x] No clippy warnings
- [x] Code formatted
- [x] Documentation complete
- [x] Follows CLAUDE.md conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Color and Vertex types and support for monochrome triangle/quad drawing with correct drawing offset/wrapping.

* **Refactor**
  * Reworked GPU command handling to a parsed, enum-driven flow and aligned reset/initialization behavior; shaded primitives are noted as pending and logged as unimplemented.

* **Tests**
  * Expanded tests for color/vertex conversions, command parsing, buffering semantics, offset behavior, and rendering pathways.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->