### PR TITLE
feat(frontend): add CD-ROM loading support to psrx-ui binary

### DIFF
--- a/src/bin/psrx-ui.rs
+++ b/src/bin/psrx-ui.rs
@@ -31,6 +31,10 @@ use std::env;
 struct Args {
     /// Path to PlayStation BIOS file (e.g., SCPH1001.BIN)
     bios_file: String,
+
+    /// Path to CD-ROM disc image (.cue file)
+    #[arg(short = 'c', long)]
+    cdrom: Option<String>,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -65,6 +69,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     info!("BIOS loaded successfully");
+
+    // Load CD-ROM disc if specified
+    if let Some(cdrom_path) = &args.cdrom {
+        info!("Loading CD-ROM disc from: {}", cdrom_path);
+        if let Err(e) = system.cdrom().borrow_mut().load_disc(cdrom_path) {
+            error!("Failed to load CD-ROM disc: {}", e);
+            return Err(Box::new(e));
+        }
+        info!("CD-ROM disc loaded successfully");
+    }
 
     // Reset system to start execution
     info!("Starting emulator...");


### PR DESCRIPTION
## Summary

Add `--cdrom` CLI argument to `psrx-ui` binary to enable loading PlayStation disc images, allowing the BIOS to access CD-ROM data and display the PlayStation logo with game discs loaded.

## Changes

- Add optional `--cdrom` argument (`-c, --cdrom <PATH>`)
- Load disc image via `system.cdrom().borrow_mut().load_disc()` before system reset
- Proper error handling and logging for disc loading operations

## Testing

✅ Successfully tested with SaGa Frontier disc image:
```bash
./target/release/psrx-ui bios/SCPH1001.BIN \
  --cdrom "assets/usa/Saga Frontier/SaGa Frontier.cue"
```

- Disc loads successfully (1 track, 689 MB)
- BIOS can access CD-ROM data
- No regression in UI functionality
- Code quality checks pass (fmt, clippy)

## Related

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading CD-ROM disc images via an optional command-line argument (-c/--cdrom). Users can now specify a CD-ROM path to load after BIOS initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->