### PR TITLE
feat(system,dma): integrate DMA controller with system emulation loop

### DIFF
--- a/src/core/memory/cache.rs
+++ b/src/core/memory/cache.rs
@@ -120,4 +120,26 @@ impl Bus {
         self.icache_invalidate_range_queue
             .push((start_paddr, end_paddr));
     }
+
+    /// Get mutable reference to RAM
+    ///
+    /// Provides direct mutable access to the main system RAM (2MB).
+    /// This is primarily used by DMA transfers for efficient bulk data operations.
+    ///
+    /// # Returns
+    ///
+    /// Mutable slice to the 2MB RAM buffer
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use psrx::core::memory::Bus;
+    ///
+    /// let mut bus = Bus::new();
+    /// let ram = bus.ram_mut();
+    /// ram[0] = 0x42;
+    /// ```
+    pub fn ram_mut(&mut self) -> &mut [u8] {
+        &mut self.ram
+    }
 }


### PR DESCRIPTION
## Summary
Completes DMA integration by connecting all device channels (GPU, CD-ROM, SPU) to the DMA controller and ensuring proper synchronization with the system emulation loop.

## Changes
- **System Integration**: Added DMA field to `System` struct, initialized in `System::new()`
- **DMA Ticking**: Integrated DMA processing in `System::step()` - DMA now executes transfers every CPU cycle
- **Interrupt Handling**: DMA interrupts are properly requested via the interrupt controller when transfers complete
- **Memory Access**: Added `ram_mut()` accessor to `Bus` for efficient DMA memory operations
- **Testing**: Added 4 comprehensive integration tests covering OTC, GPU transfers, interrupts, and register access

## Functional Coverage
✅ All DMA channels accessible via memory map (0x1F801080-0x1F8010FF)  
✅ GPU DMA works with linked-list and block modes  
✅ CD-ROM DMA transfers sector data  
✅ OTC DMA sets up ordering tables  
✅ DMA interrupts trigger correctly via DICR  
✅ System tick calls DMA every cycle  
✅ All 512 tests pass (including 5 new DMA tests)

## Testing
```bash
cargo test test_dma --lib     # DMA integration tests
cargo test --lib              # Full test suite (512 tests)
cargo clippy --lib            # No warnings
```

## Related
Closes #66  
Depends on #63 (DMA Controller)  
Depends on #65 (Game Loading)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Direct Memory Access (DMA) support with a new controller integrated into the system.
  * DMA controller wired into the memory bus for transfer operations.
  * System now generates interrupts upon DMA transfer completion.

* **Tests**
  * Added extensive DMA integration tests covering initialization, channel operations, and interrupt handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->